### PR TITLE
`put_log_flow()` の削除

### DIFF
--- a/philo/includes/philo.h
+++ b/philo/includes/philo.h
@@ -123,8 +123,6 @@ void			*monitor_cycle(void *thread_args);
 
 /* put */
 void			put_log(const t_philo *philo, const char *message);
-int64_t			put_log_flow(\
-					t_philo *philo, void (*set_time)(), const char *message);
 int				put_error(const char *message);
 
 /* usleep */

--- a/philo/srcs/philo_eat.c
+++ b/philo/srcs/philo_eat.c
@@ -34,8 +34,6 @@ void	eating(t_philo *philo)
 	const int64_t	must_eat = philo->rule.num_of_each_philo_must_eat;
 	pthread_mutex_t	*shared;
 
-	if (is_simulation_over_atomic(philo))
-		return ;
 	shared = &philo->shared->shared;
 	if (call_atomic(shared, put_log_eating, philo) == FAILURE)
 		return ;

--- a/philo/srcs/philo_eat.c
+++ b/philo/srcs/philo_eat.c
@@ -6,9 +6,15 @@ static void	set_start_cycle_time(t_philo *philo, const int64_t current_time)
 	philo->start_time_of_cycle = current_time;
 }
 
+// The required philo->current_time within put_log() is
+// set inside is_simulation_over(), thus preserving the order.
 static int64_t	put_log_eating(t_philo *philo)
 {
-	return (put_log_flow(philo, set_start_cycle_time, MSG_EAT));
+	if (is_simulation_over(philo))
+		return (FAILURE);
+	set_start_cycle_time(philo, philo->current_time);
+	put_log(philo, MSG_EAT);
+	return (SUCCESS);
 }
 
 static int64_t	count_eat_times(t_philo *philo)

--- a/philo/srcs/philo_forks.c
+++ b/philo/srcs/philo_forks.c
@@ -1,9 +1,14 @@
 #include "philo.h"
 #include "utils.h"
 
+// The required philo->current_time within put_log() is
+// set inside is_simulation_over(), thus preserving the order.
 static int64_t	put_log_fork(t_philo *philo)
 {
-	return (put_log_flow(philo, NULL, MSG_FORK));
+	if (is_simulation_over(philo))
+		return (FAILURE);
+	put_log(philo, MSG_FORK);
+	return (SUCCESS);
 }
 
 void	take_fork(pthread_mutex_t *fork, t_philo *philo)

--- a/philo/srcs/philo_forks.c
+++ b/philo/srcs/philo_forks.c
@@ -16,8 +16,6 @@ void	take_fork(pthread_mutex_t *fork, t_philo *philo)
 	pthread_mutex_t	*shared;
 
 	pthread_mutex_lock(fork);
-	if (is_simulation_over_atomic(philo))
-		return ;
 	shared = &philo->shared->shared;
 	call_atomic(shared, put_log_fork, philo);
 }

--- a/philo/srcs/philo_sleep_think.c
+++ b/philo/srcs/philo_sleep_think.c
@@ -1,9 +1,14 @@
 #include "philo.h"
 #include "utils.h"
 
+// The required philo->current_time within put_log() is
+// set inside is_simulation_over(), thus preserving the order.
 static int64_t	put_log_sleeping(t_philo *philo)
 {
-	return (put_log_flow(philo, NULL, MSG_SLEEP));
+	if (is_simulation_over(philo))
+		return (FAILURE);
+	put_log(philo, MSG_SLEEP);
+	return (SUCCESS);
 }
 
 void	sleeping(t_philo *philo)
@@ -19,9 +24,14 @@ void	sleeping(t_philo *philo)
 	usleep_gradual(time_to_sleep, philo);
 }
 
+// The required philo->current_time within put_log() is
+// set inside is_simulation_over(), thus preserving the order.
 static int64_t	put_log_thinking(t_philo *philo)
 {
-	return (put_log_flow(philo, NULL, MSG_THINK));
+	if (is_simulation_over(philo))
+		return (FAILURE);
+	put_log(philo, MSG_THINK);
+	return (SUCCESS);
 }
 
 void	thinking(t_philo *philo)

--- a/philo/srcs/philo_sleep_think.c
+++ b/philo/srcs/philo_sleep_think.c
@@ -16,8 +16,6 @@ void	sleeping(t_philo *philo)
 	const int64_t	time_to_sleep = philo->rule.time_to_sleep;
 	pthread_mutex_t	*shared;
 
-	if (is_simulation_over_atomic(philo))
-		return ;
 	shared = &philo->shared->shared;
 	if (call_atomic(shared, put_log_sleeping, philo) == FAILURE)
 		return ;
@@ -38,8 +36,6 @@ void	thinking(t_philo *philo)
 {
 	pthread_mutex_t	*shared;
 
-	if (is_simulation_over_atomic(philo))
-		return ;
 	shared = &philo->shared->shared;
 	call_atomic(shared, put_log_thinking, philo);
 }

--- a/philo/srcs/put.c
+++ b/philo/srcs/put.c
@@ -21,19 +21,6 @@ void	put_log(const t_philo *philo, const char *message)
 		printf(SPEC_I64" %d %s\n", elapsed_time, philo->id, message);
 }
 
-// call in lock
-// set philo->current_time in is_simulation_over()
-// set_time() is only used eating
-int64_t	put_log_flow(t_philo *philo, void (*set_time)(), const char *message)
-{
-	if (is_simulation_over(philo))
-		return (FAILURE);
-	if (set_time != NULL)
-		set_time(philo, philo->current_time);
-	put_log(philo, message);
-	return (SUCCESS);
-}
-
 int	put_error(const char *message)
 {
 	if (ft_putstr_fd("Error: ", STDERR_FILENO) == WRITE_ERROR)


### PR DESCRIPTION
## Issue
#1

## したこと
関数ポインタを渡していることで中身の処理が追いづらくなっている `put_log_flow()` を削除した。

## 改善された点
- 追いづらくなっていた関数の大まかな処理の流れが全て同一ファイル内で可視化され、可読性が向上した。
- その結果、プログラムの即時終了のために書いていた別の重複処理を削除することができた。

## レビュー観点
- 今まで処理をまとめていたものを分散したため、必要なコメントを全ての箇所に記載することになってしまった。
- 仮に今回削除した関数の流れに処理を追加するとなった場合に変更箇所が増えてしまう。  

などが懸念点として発生しました。

今回は規模の小さいプログラムなので可読性という観点で見ると向上したと思いますが、そのバランスのコツなどアドバイスいただけると嬉しいです。